### PR TITLE
Add PDF upload support with viewer and text interactions

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ GlobStory is an interactive web application that combines historical maps with W
 
 - Interactive historical map with time slider control
 - Wikipedia article integration with smart word and year detection
+- Optional PDF upload that renders documents alongside Wikipedia content
 - Multi-language support for various Wikipedia editions
 - Automatic location detection and highlighting for place names in articles
 - Year detection and time navigation from article content
@@ -43,14 +44,23 @@ globstory/
 - [MapLibre GL JS](https://maplibre.org/projects/maplibre-gl-js/) - For vector tile rendering
 - [Leaflet-MiniMap](https://github.com/Norkart/Leaflet-MiniMap) - For the overview map
 - [Font Awesome](https://fontawesome.com/) - For icons
+- [PDF.js](https://mozilla.github.io/pdf.js/) - For client-side PDF rendering
 
 ## Usage
 
 - Search for Wikipedia articles using the search box
+- Upload a PDF to preview it in the sidebar and keep map interactions
 - Click on place names in articles to locate them on the map
 - Click on years to navigate the historical timeline
 - Use the language selector to change the Wikipedia language
 - Customize the application behavior using the settings panel
+
+## Testing
+
+The project does not yet ship with an automated test suite. When updating the
+front-end, smoke-test the experience by opening `app.html` in a browser,
+uploading a representative PDF, and confirming that the map interactions still
+respond to highlighted places and years.
 
 ## License
 
@@ -58,4 +68,5 @@ This project is open source and available under the MIT License.
 
 ## Placeholder Files
 
-Note: The GlobStory_logo150x150.png file is a placeholder and should be replaced with an actual logo before deployment.
+Note: The GlobStory_logo150x150.png file is a placeholder and should be
+replaced with an actual logo before deployment.

--- a/app.html
+++ b/app.html
@@ -30,6 +30,9 @@
     <!-- Font Awesome for icons -->
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css" />
 
+    <!-- PDF.js for PDF rendering -->
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/pdf.js/3.11.174/pdf.min.js"></script>
+
     <!-- Custom CSS -->
     <link rel="stylesheet" href="css/styles.css" />
     <link rel="stylesheet" href="css/onboarding.css" />
@@ -269,9 +272,32 @@
             <div class="language-indicator" id="search-language-indicator">
                 Searching in: <strong>English</strong> Wikipedia
             </div>
+            <div id="pdf-upload-container">
+                <button id="pdf-upload-button" class="pdf-upload-button">
+                    <i class="fas fa-file-pdf"></i>
+                    <span>Upload PDF</span>
+                </button>
+                <input type="file" id="pdf-file-input" accept="application/pdf" hidden>
+            </div>
             <input type="text" id="search-box" placeholder="Search Wikipedia...">
             <div id="search-results"></div>
-            
+
+            <div id="pdf-viewer-container" class="hidden">
+                <div id="pdf-viewer-header">
+                    <div class="pdf-viewer-title">
+                        <i class="fas fa-file-pdf"></i>
+                        <span id="pdf-file-name">Uploaded PDF</span>
+                    </div>
+                    <button id="pdf-close-button" class="pdf-close-button">
+                        <i class="fas fa-rotate-left"></i> Back to Wikipedia
+                    </button>
+                </div>
+                <p class="pdf-viewer-tip">
+                    The PDF is rendered below. Scroll further down to see the extracted text with map interactions enabled.
+                </p>
+                <div id="pdf-viewer"></div>
+            </div>
+
             <!-- Article navigation bar -->
             <div id="article-nav-bar">
                 <button id="back-button" class="article-nav-button">

--- a/css/styles.css
+++ b/css/styles.css
@@ -77,6 +77,105 @@ body, html {
     padding: 10px;
 }
 
+#wiki-section.pdf-mode {
+    background-color: #ffffff;
+}
+
+.hidden {
+    display: none !important;
+}
+
+#pdf-upload-container {
+    display: flex;
+    justify-content: flex-start;
+    gap: 10px;
+    margin-bottom: 10px;
+}
+
+.pdf-upload-button {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    background-color: #c0392b;
+    color: #fff;
+    border: none;
+    border-radius: 4px;
+    padding: 8px 12px;
+    cursor: pointer;
+    font-weight: 600;
+    box-shadow: 0 1px 3px rgba(0, 0, 0, 0.1);
+    transition: background-color 0.2s ease;
+}
+
+.pdf-upload-button:hover {
+    background-color: #922b21;
+}
+
+#pdf-viewer-container {
+    background: #ffffff;
+    border-radius: 6px;
+    padding: 12px;
+    margin-bottom: 12px;
+    box-shadow: 0 2px 6px rgba(0, 0, 0, 0.08);
+}
+
+#pdf-viewer-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    margin-bottom: 10px;
+}
+
+.pdf-viewer-title {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    font-weight: 600;
+    color: #2c3e50;
+}
+
+#pdf-file-name {
+    word-break: break-word;
+}
+
+.pdf-close-button {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    background-color: #34495e;
+    color: #fff;
+    border: none;
+    border-radius: 4px;
+    padding: 6px 12px;
+    cursor: pointer;
+    font-weight: 600;
+    transition: background-color 0.2s ease;
+}
+
+.pdf-close-button:hover {
+    background-color: #2c3e50;
+}
+
+.pdf-viewer-tip {
+    font-size: 0.85em;
+    color: #555;
+    margin-bottom: 12px;
+}
+
+#pdf-viewer {
+    display: flex;
+    flex-direction: column;
+    gap: 16px;
+}
+
+#pdf-viewer canvas {
+    width: 100%;
+    height: auto;
+    border: 1px solid #ddd;
+    border-radius: 4px;
+    box-shadow: 0 2px 6px rgba(0, 0, 0, 0.06);
+}
+
 /* Search box */
 #search-box {
     width: calc(100% - 20px);


### PR DESCRIPTION
## Summary
- integrate pdf.js on the client and expose an upload button in the wiki panel so users can load PDFs alongside existing Wikipedia search
- render uploaded PDFs in a dedicated viewer and extract their text to keep map interactions active on recognized places and years
- add styling and visibility toggles so users can switch back to the Wikipedia view when desired
- document the PDF workflow and note the current manual smoke-test expectations in the README

## Testing
- attempted to run `npx --yes prettier@3.2.5 --check app.html css/styles.css js/main.js` *(fails: npm registry access is forbidden in this environment)*

------
https://chatgpt.com/codex/tasks/task_b_68f2165a0b2483228e5bac8d5752a100